### PR TITLE
:sparkles: Cadastro de Usuário mais seguro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,6 +85,7 @@ dependencies = [
  "serde_json",
  "time 0.3.41",
  "totp-rs",
+ "uuid 1.16.0",
  "validator",
 ]
 
@@ -1592,7 +1593,7 @@ dependencies = [
  "lettre 0.9.6",
  "mime",
  "time 0.1.45",
- "uuid",
+ "uuid 0.7.4",
 ]
 
 [[package]]
@@ -2981,6 +2982,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90dbc611eb48397705a6b0f6e917da23ae517e4d127123d2cf7674206627d32a"
 dependencies = [
  "rand 0.6.5",
+]
+
+[[package]]
+name = "uuid"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
+dependencies = [
+ "getrandom 0.3.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,4 @@ validator = { version = "0.16", features = ["derive"] }
 regex = "1.11.1"
 serde_json = "1.0.140"
 redis = { version = "0.29.5", features = ["tokio-comp"] }
+uuid = { version = "1.16.0", features = ["v7"] }

--- a/migrations/2025-02-15-205046_create_users/up.sql
+++ b/migrations/2025-02-15-205046_create_users/up.sql
@@ -3,7 +3,7 @@ CREATE TABLE users (
     id SERIAL PRIMARY KEY,
     name VARCHAR NOT NULL,
     email VARCHAR NOT NULL UNIQUE,
-    password VARCHAR NOT NULL,
+    password VARCHAR,
     two_factor_secret TEXT,
     two_factor_recovery_code TEXT,
     two_factor_confirmed_at timestamp with time zone,

--- a/src/http/controllers/auth_controller.rs
+++ b/src/http/controllers/auth_controller.rs
@@ -31,37 +31,103 @@ pub async fn login(req: HttpRequest, body: web::Json<AuthLoginRequest>) -> impl 
                         Some(_confirmed_at) => {
                                 
                                 // Verificar se a senha está correta
-                                let result = bcrypt::verify(body.password.as_bytes(),&user.password.as_ref()).unwrap();
+                                match &user.password {
+                                    Some(user_password) => {
+                                        let result = bcrypt::verify(body.password.as_bytes(),user_password).unwrap();
 
-                                if result == true {
-                                    let app_name = dotenv!("APP_NAME");
+                                        if result == true {
+                                            let app_name = dotenv!("APP_NAME");
+                                            
+                                            // Aproximar o valor da data/hora para o horario Unix (segundos desde 01/01/1970)
+                                            let seconds_now = ((Utc::now().timestamp_millis()) / 1000) as u64;
+                                            
+                                            let totp = TOTP::new(
+                                                Algorithm::SHA512,
+                                                6,
+                                                1,
+                                                30,
+                                                Secret::Encoded(user.two_factor_secret.unwrap()).to_bytes().unwrap(),
+                                                Some(app_name.to_string()),
+                                                user.email.clone()
+                                            ).unwrap();
+        
+                                            /* 
+                                                * Pegar a referência do código passado na requisição 
+                                                * (Se não tiver, pega uma ref. de String vazia)
+                                            */
+                                            let code = &body.code.clone().unwrap_or_else(|| "".to_owned());
+        
+                                            // Checar se o código é valido, dado o horario Unix
+                                            if totp.check(code, seconds_now) == true {
+        
+                                                // Se válido, retornar o token de acesso para o usuário
+                                                let token = encode_jwt(user.email);        
+                                                
+                                                let response = AuthLoginResponse {
+                                                    message: "Login successful",
+                                                    token: Some(&token)
+                                                }; 
+                                
+                                                return HttpResponse::Ok()
+                                                    .content_type(ContentType::json())
+                                                    .json(response);
+                                            } else {
+                                                /*
+                                                    * Se o código do 2FA não é valido, 
+                                                    * verificar se o código foi passado é de fato invalido (Cod. 401)
+                                                */
+                                                
+                                                let response = GenericResponse {
+                                                    message: "2FA challenge failed! Try again."
+                                                };
+        
+                                                brute_force_protection(req).await;
+                
+                                                return HttpResponse::Unauthorized()
+                                                    .content_type(ContentType::json())
+                                                    .json(response);
+                                                    
+                                            }
+                                        } else {
+                                            
+                                            // Caso email ou senha forem invalidos (COM 2FA)
+                                            let response = AuthLoginError{
+                                                message: "Error trying to Login!",
+                                                error: "Invalid email or password."
+                                            };
+        
+                                            brute_force_protection(req).await;
+                            
+                                            return HttpResponse::NotFound()
+                                                .content_type(ContentType::json())
+                                                .json(response);
+                                        }
+                                    },
+                                    None => {
+                                        let res_err = AuthLoginError {
+                                            message: "You have not set your user password yet!",
+                                            error: "Error trying update user!"
+                                        };
+            
+                                        return HttpResponse::Conflict()
+                                        .content_type(ContentType::json())
+                                        .json(res_err);
+                                    }
+                                }
+                                
+                            },
+                        None => {
+
+                            // Sem 2FA, apenas verificar se a senha está correta
+                            match &user.password {
+                                Some(user_password) => {
+                                    let result = bcrypt::verify(body.password.as_bytes(),user_password).unwrap();
                                     
-                                    // Aproximar o valor da data/hora para o horario Unix (segundos desde 01/01/1970)
-                                    let seconds_now = ((Utc::now().timestamp_millis()) / 1000) as u64;
-                                    
-                                    let totp = TOTP::new(
-                                        Algorithm::SHA512,
-                                        6,
-                                        1,
-                                        30,
-                                        Secret::Encoded(user.two_factor_secret.unwrap()).to_bytes().unwrap(),
-                                        Some(app_name.to_string()),
-                                        user.email.clone()
-                                    ).unwrap();
-
-                                    /* 
-                                        * Pegar a referência do código passado na requisição 
-                                        * (Se não tiver, pega uma ref. de String vazia)
-                                    */
-                                    let code = &body.code.clone().unwrap_or_else(|| "".to_owned());
-
-                                    // Checar se o código é valido, dado o horario Unix
-                                    if totp.check(code, seconds_now) == true {
-
-                                        // Se válido, retornar o token de acesso para o usuário
-                                        let token = encode_jwt(user.email);        
+                                    if result == true {
                                         
-                                        let response = AuthLoginResponse {
+                                        // Enviar token e msg de sucesso para o usuário
+                                        let token = encode_jwt(user.email);        
+                                        let response = AuthLoginResponse{
                                             message: "Login successful",
                                             token: Some(&token)
                                         }; 
@@ -70,67 +136,30 @@ pub async fn login(req: HttpRequest, body: web::Json<AuthLoginRequest>) -> impl 
                                             .content_type(ContentType::json())
                                             .json(response);
                                     } else {
-                                        /*
-                                            * Se o código do 2FA não é valido, 
-                                            * verificar se o código foi passado é de fato invalido (Cod. 401)
-                                        */
                                         
-                                        let response = GenericResponse {
-                                            message: "2FA challenge failed! Try again."
+                                        // Caso email ou senha forem invalidos (sem 2FA)
+                                        let response = AuthLoginError{
+                                            message: "Error trying to Login!",
+                                            error: "Invalid email or password."
                                         };
 
                                         brute_force_protection(req).await;
-        
-                                        return HttpResponse::Unauthorized()
+                        
+                                        return HttpResponse::NotFound()
                                             .content_type(ContentType::json())
                                             .json(response);
-                                            
                                     }
-                                } else {
-                                    
-                                    // Caso email ou senha forem invalidos (COM 2FA)
-                                    let response = AuthLoginError{
-                                        message: "Error trying to Login!",
-                                        error: "Invalid email or password."
+                                },
+                                None => {
+                                    let res_err = AuthLoginError {
+                                        message: "You have not set your user password yet!",
+                                        error: "Error trying update user!"
                                     };
-
-                                    brute_force_protection(req).await;
-                    
-                                    return HttpResponse::NotFound()
-                                        .content_type(ContentType::json())
-                                        .json(response);
+        
+                                    return HttpResponse::Conflict()
+                                    .content_type(ContentType::json())
+                                    .json(res_err);
                                 }
-                            },
-                        None => {
-
-                            // Sem 2FA, apenas verificar se a senha está correta
-                            let result = bcrypt::verify(body.password.as_bytes(),&user.password).unwrap();
-                            
-                            if result == true {
-                                
-                                // Enviar token e msg de sucesso para o usuário
-                                let token = encode_jwt(user.email);        
-                                let response = AuthLoginResponse{
-                                    message: "Login successful",
-                                    token: Some(&token)
-                                }; 
-                
-                                return HttpResponse::Ok()
-                                    .content_type(ContentType::json())
-                                    .json(response);
-                            } else {
-                                
-                                // Caso email ou senha forem invalidos (sem 2FA)
-                                let response = AuthLoginError{
-                                    message: "Error trying to Login!",
-                                    error: "Invalid email or password."
-                                };
-
-                                brute_force_protection(req).await;
-                
-                                return HttpResponse::NotFound()
-                                    .content_type(ContentType::json())
-                                    .json(response);
                             }
                         }
                     }

--- a/src/http/controllers/user_controller.rs
+++ b/src/http/controllers/user_controller.rs
@@ -2,13 +2,13 @@ use actix_web::{ http::header::ContentType, middleware::from_fn, web::{self, Ser
 use base32::{encode, Alphabet};
 use chrono::Utc;
 use diesel::{ ExpressionMethods, QueryDsl, SelectableHelper, TextExpressionMethods };
-use diesel_async::RunQueryDsl;
+use diesel_async::{scoped_futures::ScopedFutureExt, AsyncConnection, RunQueryDsl};
 use lazy_static::lazy_static;
 use lettre::{message::{header, SinglePart}, transport::smtp::authentication::{Credentials, Mechanism}, Message, SmtpTransport, Transport};
 use totp_rs::{Algorithm, Secret, TOTP};
 use uuid::{ContextV7, Timestamp, Uuid};
 use validator::Validate;
-use crate::{database::db::get_connection, http::{middleware::auth_middleware::auth_middleware, requests::user::{user_activate2fa_request::UserActivate2FARequest, user_activate_request::UserActivateRequest, user_filter_request::UserFilterRequest, user_store_request::UserStoreRequest, user_update_request::UserUpdateRequest}, responses::{auth::auth_login_response::AuthLoginError, email::email_sent_response::EmailSendError, user::{user_delete_response::{UserDeleteError, UserDeleteResponse}, user_enable2fa_response::UserEnable2FAResponse, user_index_response::UserIndexResponse, user_store_response::{UserStoreError, UserStoreResponse}, user_update_response::{UserUpdateError, UserUpdateResponse}}}, GenericError, GenericResponse}, model::user::{user::User, user_dto::{UserDTO, UserDTOMin}}, schema::users::{self}, services::{auth::decode_jwt, redis_client::{cache_get_key, cache_set_key}}};
+use crate::{database::db::get_connection, http::{middleware::auth_middleware::auth_middleware, requests::user::{user_activate2fa_request::UserActivate2FARequest, user_activate_request::UserActivateRequest, user_filter_request::UserFilterRequest, user_store_request::UserStoreRequest, user_update_request::UserUpdateRequest, user_resend_activation_hash_request::UserResendActivationHashRequest}, responses::{auth::auth_login_response::AuthLoginError, email::email_sent_response::EmailSendError, user::{user_delete_response::{UserDeleteError, UserDeleteResponse}, user_enable2fa_response::UserEnable2FAResponse, user_index_response::UserIndexResponse, user_store_response::{UserStoreError, UserStoreResponse}, user_update_response::{UserUpdateError, UserUpdateResponse}}}, GenericError, GenericResponse}, model::user::{user::User, user_dto::{UserDTO, UserDTOMin}}, schema::users::{self}, services::{auth::decode_jwt, redis_client::{cache_del_key, cache_get_key, cache_set_key}}};
 use crate::schema::users::dsl::*;
 use base64::{prelude::BASE64_STANDARD_NO_PAD, Engine};
 use rand::Rng;
@@ -121,90 +121,127 @@ pub async fn store(body: web::Json<UserStoreRequest>) -> impl Responder {
             };
         
             let conn = &mut get_connection().await.unwrap();
-            
-            // Query para criar o usuário
-            let create_user = diesel::insert_into(users::table)
-                .values(&new_user)
+
+            let check_user_already_exists = users::table
+                .filter(users::email.eq(&new_user.email))
+                .select(User::as_select())
                 .get_result::<User>(conn)
                 .await;
-        
-            match create_user {
-                Ok(user_created) => {
-        
-                    // Preparar dados da resposta
-                    let response = UserStoreResponse{
-                        message: "User stored successfuly!",
-                        user: user_created.clone()
+
+            match check_user_already_exists {
+                Ok(_user) => {
+                    let user_exists_res = UserStoreError {
+                        message: "Email already being used!",
+                        error: "A user with this same email already exists."
                     };
 
-                    let context = ContextV7::new();
-                    let time_unix = Timestamp::now(&context).to_unix();
-
-                    let uuid_user = Uuid::new_v7(
-                        Timestamp::from_unix(&context,time_unix.0, time_unix.1)
-                    );
-
-                    let _ = cache_set_key::<&str, String, ()>(
-                        &format!("user:{}:uuid_user_activate", &user_created.id),
-                        uuid_user.to_string(),
-                        86400
-                    ).await;
-
-                    let message_email = format!("This is your Token for define your password {}", uuid_user.to_string());
-
-                    let email_text_body = SinglePart::builder()
-                        .header(header::ContentType::TEXT_PLAIN)
-                        .body(message_email);
-
-                    // Ler dados do usuário da aplicação (.env) e de quem vai receber o email
-                    let google_email = dotenv!("EMAIL");
-                    let user_receiver = user_created.email;
-                    let google_token = dotenv!("GOOGLE_TOKEN");
-                    
-                    // Criar o Email
-                    let email_singlepart = Message::builder()
-                        .from(google_email.parse().unwrap())
-                        .to(user_receiver.parse().unwrap())
-                        .subject("Ativar conta Logistica-APP")
-                        .singlepart(email_text_body).unwrap();
-
-                    // Resgatar as credenciais para conexão segura
-                    let creds = Credentials::new(google_email.to_owned(), google_token.to_owned());
-
-                    // Construtor do algoritmo de transporte pelo serviço do Gmail
-                    let mailer = SmtpTransport::starttls_relay("smtp.gmail.com").expect("Error creating StartTLS Transport")
-                        .authentication(vec![Mechanism::Plain])
-                        .credentials(creds)
-                        .build();
-
-                    // Enviar email e verificar se o envio deu certo
-                    match mailer.send(&email_singlepart) { // Resposta com status 200
-                        Ok(_) => return HttpResponse::Ok()
-                            .content_type(ContentType::json())
-                            .json(response),
-                        Err(e) => HttpResponse::BadGateway()
-                            .content_type(ContentType::json())
-                            .json(EmailSendError {
-                                message: "Error sending email!",
-                                error: &e.to_string()
-                            }),
-                    }
-                    
-                    
-                },
-                Err(error) => {
-                    let error_msg = error.to_string();
-        
-                    // Preparar dados do erro interno para a resposta
-                    let response = UserStoreError{
-                        message: "Error while trying store User!",
-                        error: &error_msg
-                    };
-                    
-                    // Retornar dados com status 500
-                    return HttpResponse::InternalServerError()
+                    return HttpResponse::Conflict()
                         .content_type(ContentType::json())
-                        .json(response);
+                        .json(user_exists_res);
+                },
+                Err(_) => {
+                    
+                    // Query para criar o usuário
+                    let create_user = diesel::insert_into(users::table)
+                    .values(&new_user)
+                    .get_result::<User>(conn)
+                    .await;
+
+                    match create_user {
+                        Ok(user_created) => {
+                
+                            // Preparar dados da resposta
+                            let response = UserStoreResponse{
+                                message: "User stored successfuly!",
+                                user: user_created.clone()
+                            };
+        
+                            let context = ContextV7::new();
+                            let time_unix = Timestamp::now(&context).to_unix();
+        
+                            let uuid_user = Uuid::new_v7(
+                                Timestamp::from_unix(&context,time_unix.0, time_unix.1)
+                            );
+        
+                            let cache_uuid = cache_set_key::<&str, String, ()>(
+                                &format!("user:{}:uuid_user_activate", &user_created.id),
+                                uuid_user.to_string(),
+                                86400
+                            ).await;
+        
+                            match cache_uuid {
+                                Ok(_) => {
+                                    let message_email = format!("This is your Token for define your password {}", uuid_user.to_string());
+        
+                                    let email_text_body = SinglePart::builder()
+                                        .header(header::ContentType::TEXT_PLAIN)
+                                        .body(message_email);
+                
+                                    // Ler dados do usuário da aplicação (.env) e de quem vai receber o email
+                                    let google_email = dotenv!("EMAIL");
+                                    let user_receiver = user_created.email;
+                                    let google_token = dotenv!("GOOGLE_TOKEN");
+                                    
+                                    // Criar o Email
+                                    let email_singlepart = Message::builder()
+                                        .from(google_email.parse().unwrap())
+                                        .to(user_receiver.parse().unwrap())
+                                        .subject("Ativar conta Logistica-APP")
+                                        .singlepart(email_text_body).unwrap();
+                
+                                    // Resgatar as credenciais para conexão segura
+                                    let creds = Credentials::new(google_email.to_owned(), google_token.to_owned());
+                
+                                    // Construtor do algoritmo de transporte pelo serviço do Gmail
+                                    let mailer = SmtpTransport::starttls_relay("smtp.gmail.com").expect("Error creating StartTLS Transport")
+                                        .authentication(vec![Mechanism::Plain])
+                                        .credentials(creds)
+                                        .build();
+                
+                                    // Enviar email e verificar se o envio deu certo
+                                    match mailer.send(&email_singlepart) { // Resposta com status 200
+                                        Ok(_) => return HttpResponse::Ok()
+                                            .content_type(ContentType::json())
+                                            .json(response),
+                                        Err(e) => HttpResponse::BadGateway()
+                                            .content_type(ContentType::json())
+                                            .json(EmailSendError {
+                                                message: "Error sending email!",
+                                                error: &e.to_string()
+                                            }),
+                                    }
+                                },
+                                Err(error) => {
+                                    let error_msg = error.to_string();
+        
+                                    // Preparar dados do erro interno para a resposta
+                                    let response = GenericError {
+                                        message: "Error while setting uuid key in cache!",
+                                        error: &error_msg
+                                    };
+                                    
+                                    // Retornar dados com status 500
+                                    return HttpResponse::InternalServerError()
+                                        .content_type(ContentType::json())
+                                        .json(response);
+                                }
+                            }
+                        },
+                        Err(error) => {
+                            let error_msg = error.to_string();
+                
+                            // Preparar dados do erro interno para a resposta
+                            let response = UserStoreError{
+                                message: "Error while trying store User!",
+                                error: &error_msg
+                            };
+                            
+                            // Retornar dados com status 500
+                            return HttpResponse::InternalServerError()
+                                .content_type(ContentType::json())
+                                .json(response);
+                        }
+                    }
                 }
             }
         },
@@ -468,7 +505,6 @@ pub async fn delete_my_account(req: HttpRequest) -> impl Responder{
 }
 
 pub async fn activate_user(
-    req: HttpRequest, 
     path: web::Path<String>, 
     body: web::Json<UserActivateRequest>
 ) -> impl Responder {
@@ -476,82 +512,188 @@ pub async fn activate_user(
     
     match validate {
         Ok(_) => {
-            let data = body.into_inner();
-            let auth_token = req
-                .headers()
-                .get("authorization").unwrap();
-        
-            match decode_jwt(auth_token.to_str().expect("Error casting header value to &str!")) {
-                Ok(claims) => {
-                    let conn = &mut get_connection().await.unwrap();
-                    let email_user = claims.sub;
-        
-                    let mut found_user = users::table
-                        .filter(users::email.eq(email_user))
-                        .select(User::as_select())
-                        .get_result::<User>(conn)
-                        .await
-                        .expect("User not found! Query failed!");
 
-                    let key_value = format!("user:{}:uuid_user_activate", found_user.id);
+                let data = body.into_inner();
+                let conn = &mut get_connection().await.unwrap();
+                let email_user = data.email;
 
-                    let uuid = path.into_inner();
-                    let key_exists = cache_get_key::<&str, String>(&key_value).await;
+                let mut found_user = users::table
+                    .filter(users::email.eq(email_user))
+                    .select(User::as_select())
+                    .get_result::<User>(conn)
+                    .await
+                    .expect("User not found! Query failed!");
 
-                    if uuid.eq(&key_exists) {
-                        let new_password_hashed = match bcrypt::hash(&data.new_password, BCRYPT_COST.to_owned()) {
-                            Ok(password_data) => password_data,
-                            Err(_err) => panic!("Error while bcrypt password")
-                        };
-                            
-                        found_user.password = Some(new_password_hashed);
-                        found_user.updated_at = Some(Utc::now());
-    
+                let key_value = format!("user:{}:uuid_user_activate", found_user.id);
+            
+                if path.into_inner() == cache_get_key::<&str, String>(&key_value).await.unwrap() {
+                    let new_password_hashed = match bcrypt::hash(
+                            &data.new_password, 
+                            BCRYPT_COST.to_owned()
+                        ) {
+                        Ok(password_data) => password_data,
+                        Err(_err) => panic!("Error while bcrypt password")
+                    };
+                    
+                    found_user.password = Some(new_password_hashed);
+                    found_user.updated_at = Some(Utc::now());
+
+                    let update_query = conn.transaction(
+                        |con| async move {
+                        
                         let update_user_password = diesel::update(users::table
                             .filter(users::id.eq(found_user.id))
                             ).set(found_user)
-                            .get_result::<User>(conn)
-                            .await
-                            .expect("Error updating user!");
-    
-                        let updated_user_response = UserUpdateResponse {
-                            message: "User updated",
-                            user: update_user_password
-                        };
-                        
-                        return HttpResponse::Ok()
-                            .content_type(ContentType::json())
-                            .json(updated_user_response);
-                    } else {
-                        let uuid_not_exists_err = UserUpdateError {
-                            message: "Bad Request while activating user!",
-                            error: "UUID do not exists."
-                        };
+                            .get_result::<User>(con)
+                            .await;
 
-                        return HttpResponse::BadRequest().content_type(ContentType::json()).json(uuid_not_exists_err);
-                    }
-        
+
+                        return update_user_password;
+                        
+                    }.scope_boxed()).await;
                     
-                },
-                Err(error) => {
-                    let internal_err = UserUpdateError {
-                        message: "Internal server error activating user!",
-                        error: &error.to_string()
+                    cache_del_key::<String, String>(key_value).await.unwrap();
+
+                    match update_query {
+                        Ok(_user) => {
+                            let user_activated_response = GenericResponse {
+                                message: "User activated successfully!"
+                            };
+
+                            return HttpResponse::Ok()
+                            .content_type(ContentType::json())
+                            .json(user_activated_response);
+                        },
+                        Err(_) => {
+                            let query_error_response = GenericError {
+                                message: "Internal server error while activating user!",
+                                error: "Error in activate user query in database."
+                            };
+
+                            return HttpResponse::InternalServerError()
+                            .content_type(ContentType::json())
+                            .json(query_error_response);
+                        }
+                    }
+                } else {
+                    let uuid_not_exists_err = UserUpdateError {
+                        message: "Bad Request while activating user!",
+                        error: "UUID do not exists."
                     };
 
-                    return HttpResponse::InternalServerError()
+                    return HttpResponse::BadRequest().content_type(ContentType::json()).json(uuid_not_exists_err);
+                }
+            }, Err(error) => {
+            return HttpResponse::BadRequest().content_type(ContentType::json()).json(error);
+        }
+    }
+}
+
+async fn resend_user_activation_hash(body: web::Json<UserResendActivationHashRequest>) -> impl Responder {
+
+    let validate = body.validate();
+    
+    match validate {
+        Ok(_) => {
+            let data = body.into_inner();
+            let conn = &mut get_connection().await.unwrap();
+            
+            let found_user = users::table
+                .filter(users::email.eq(data.email))
+                .select(User::as_select())
+                .get_result::<User>(conn)
+                .await;
+
+            match found_user {
+                Ok(user) => {
+
+                    let context = ContextV7::new();
+                    let time_unix = Timestamp::now(&context).to_unix();
+
+                    let uuid_user = Uuid::new_v7(
+                        Timestamp::from_unix(&context,time_unix.0, time_unix.1)
+                    );
+
+                    let cache_uuid = cache_set_key::<&str, String, ()>(
+                        &format!("user:{}:uuid_user_activate", &user.id),
+                        uuid_user.to_string(),
+                        86400
+                    ).await;
+
+                    match cache_uuid {
+                        Ok(_) => {
+                            let message_email = format!("This is your Token for define your password {}", uuid_user.to_string());
+
+                            let email_text_body = SinglePart::builder()
+                                .header(header::ContentType::TEXT_PLAIN)
+                                .body(message_email);
+
+                            // Ler dados do usuário da aplicação (.env) e de quem vai receber o email
+                            let google_email = dotenv!("EMAIL");
+                            let user_receiver = user.email;
+                            let google_token = dotenv!("GOOGLE_TOKEN");
+                            
+                            // Criar o Email
+                            let email_singlepart = Message::builder()
+                                .from(google_email.parse().unwrap())
+                                .to(user_receiver.parse().unwrap())
+                                .subject("Ativar conta Logistica-APP")
+                                .singlepart(email_text_body).unwrap();
+
+                            // Resgatar as credenciais para conexão segura
+                            let creds = Credentials::new(google_email.to_owned(), google_token.to_owned());
+
+                            // Construtor do algoritmo de transporte pelo serviço do Gmail
+                            let mailer = SmtpTransport::starttls_relay("smtp.gmail.com").expect("Error creating StartTLS Transport")
+                                .authentication(vec![Mechanism::Plain])
+                                .credentials(creds)
+                                .build();
+
+                            let response = GenericResponse {
+                                message: "A new hash sent to your email!"
+                            };
+
+                            match mailer.send(&email_singlepart) {
+                                Ok(_) => return HttpResponse::Ok()
+                                    .content_type(ContentType::json())
+                                    .json(response),
+                                Err(e) => return HttpResponse::BadGateway()
+                                    .content_type(ContentType::json())
+                                    .json(EmailSendError {
+                                        message: "Error sending email!",
+                                        error: &e.to_string()
+                                    }),
+                            }
+                        },
+                        Err(error) => {
+                            let error_msg = error.to_string();
+
+                            let response = GenericError {
+                                message: "Error while setting uuid key in cache!",
+                                error: &error_msg
+                            };
+                            
+                            return HttpResponse::InternalServerError()
+                                .content_type(ContentType::json())
+                                .json(response);
+                        }
+                    }
+                } Err(_error) => {
+                    let user_not_found_res = GenericError {
+                        message: "User Not Found!",
+                        error: "User with this email not exists in our App."
+                    };
+
+                    return HttpResponse::NotFound()
                         .content_type(ContentType::json())
-                        .json(internal_err);
+                        .json(user_not_found_res);
                 }
             }
-        
-        
         },
         Err(error) => {
             return HttpResponse::BadRequest().content_type(ContentType::json()).json(error);
         }
     }
-
 }
 
 /// Endpoint para solicitar ativação da Autenticação de dois fatores
@@ -867,6 +1009,8 @@ pub async fn activate_2fa(req: HttpRequest, body: web::Json<UserActivate2FAReque
 pub fn config(cfg: &mut ServiceConfig) {
     cfg.service(
 web::scope("/users")
+            .route("/resend-activation-hash", web::post().to(resend_user_activation_hash))
+            .route("/activate-user/{uuid}", web::put().to(activate_user))
             .service(web::scope("")
                 .route("/deleteMyAccount",web::delete().to(delete_my_account))
                 .route("/update/{id}", web::put().to(update))
@@ -874,7 +1018,6 @@ web::scope("/users")
                 .route("/enable-2fa", web::get().to(enable_2fa))
                 .route("/activate-2fa", web::post().to(activate_2fa))
                 .route("/store", web::post().to(store))
-                .route("/activate-user/{id}", web::put().to(activate_user))
                 .wrap(from_fn(auth_middleware))
             )
     );

--- a/src/http/middleware/auth_middleware.rs
+++ b/src/http/middleware/auth_middleware.rs
@@ -42,11 +42,6 @@ pub async fn auth_middleware(
 
     if let Some(token) = req.headers().get("authorization") {
 
-        let client = &mut redis::Client::open(REDIS_URL.to_owned())
-                    .unwrap()
-                    .get_multiplexed_tokio_connection()
-                    .await
-                    .unwrap();
 
         match decode_jwt(token.to_str().expect("Error casting headervalue to &str")) {
             Ok(claim) => {
@@ -75,6 +70,11 @@ pub async fn auth_middleware(
             Err(_error) => {
                 let ip_address = req.connection_info().peer_addr().unwrap().to_owned();
 
+                let client = &mut redis::Client::open(REDIS_URL.to_owned())
+                    .unwrap()
+                    .get_multiplexed_tokio_connection()
+                    .await
+                    .unwrap();
                 
                 let has_ip = client.get::<&str, u32>(&ip_address).await;
 

--- a/src/http/requests/user/mod.rs
+++ b/src/http/requests/user/mod.rs
@@ -2,3 +2,4 @@ pub mod user_store_request;
 pub mod user_update_request;
 pub mod user_filter_request;
 pub mod user_activate2fa_request;
+pub mod user_activate_request;

--- a/src/http/requests/user/mod.rs
+++ b/src/http/requests/user/mod.rs
@@ -3,3 +3,4 @@ pub mod user_update_request;
 pub mod user_filter_request;
 pub mod user_activate2fa_request;
 pub mod user_activate_request;
+pub mod user_resend_activation_hash_request;

--- a/src/http/requests/user/user_activate_request.rs
+++ b/src/http/requests/user/user_activate_request.rs
@@ -1,0 +1,10 @@
+use serde::Deserialize;
+use validator::Validate;
+
+#[derive(Debug, Deserialize, Validate)]
+pub struct UserActivateRequest {
+    #[validate(must_match(other = "new_password", message="New password confirmation failed!"))]
+    pub confirm_new_password: String,
+    #[validate(must_match(other = "confirm_new_password", message="New password confirmation failed!"))]
+    pub new_password: String,
+}

--- a/src/http/requests/user/user_activate_request.rs
+++ b/src/http/requests/user/user_activate_request.rs
@@ -3,6 +3,8 @@ use validator::Validate;
 
 #[derive(Debug, Deserialize, Validate)]
 pub struct UserActivateRequest {
+    #[validate(email)]
+    pub email: String,
     #[validate(must_match(other = "new_password", message="New password confirmation failed!"))]
     pub confirm_new_password: String,
     #[validate(must_match(other = "confirm_new_password", message="New password confirmation failed!"))]

--- a/src/http/requests/user/user_resend_activation_hash_request.rs
+++ b/src/http/requests/user/user_resend_activation_hash_request.rs
@@ -1,0 +1,8 @@
+use serde::Deserialize;
+use validator::Validate;
+
+#[derive(Debug, Deserialize, Validate)]
+pub struct UserResendActivationHashRequest {
+    #[validate(email)]
+    pub email: String
+}

--- a/src/http/requests/user/user_store_request.rs
+++ b/src/http/requests/user/user_store_request.rs
@@ -5,6 +5,5 @@ use validator::Validate;
 pub struct UserStoreRequest {
     pub name: String,
     #[validate(email(message = "Invalid email! Insert a valid email."))]
-    pub email: String,
-    pub password: String
+    pub email: String
 }

--- a/src/model/user/user.rs
+++ b/src/model/user/user.rs
@@ -5,11 +5,12 @@ use crate::schema::users;
 
 #[derive(Queryable, Identifiable, Selectable, Debug, PartialEq, Serialize, Deserialize, Clone, AsChangeset)]
 #[diesel(table_name = users)]
+#[diesel(treat_none_as_null = true)]
 pub struct User {
     pub id: i32,
     pub name: String,
     pub email: String,
-    pub password: String,
+    pub password: Option<String>,
     pub two_factor_secret: Option<String>,
     pub two_factor_recovery_code: Option<String>,
     pub two_factor_confirmed_at: Option<DateTime<Utc>>,

--- a/src/model/user/user_dto.rs
+++ b/src/model/user/user_dto.rs
@@ -9,7 +9,7 @@ use crate::schema::users;
 pub struct UserDTO {
     pub name: String,
     pub email: String,
-    pub password: String,
+    pub password: Option<String>,
     pub two_factor_secret: Option<String>,
     pub two_factor_recovery_code: Option<String>,
     pub two_factor_confirmed_at: Option<DateTime<Utc>>,

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -36,7 +36,7 @@ diesel::table! {
         id -> Int4,
         name -> Varchar,
         email -> Varchar,
-        password -> Varchar,
+        password -> Nullable<Varchar>,
         two_factor_secret -> Nullable<Text>,
         two_factor_recovery_code -> Nullable<Text>,
         two_factor_confirmed_at -> Nullable<Timestamptz>,

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -1,2 +1,3 @@
 pub mod auth;
 pub mod brute_force_protection;
+pub mod redis_client;

--- a/src/services/redis_client.rs
+++ b/src/services/redis_client.rs
@@ -1,6 +1,6 @@
 use lazy_static::lazy_static;
 use dotenvy_macro::dotenv;
-use redis::AsyncCommands;
+use redis::{AsyncCommands, RedisError};
 use redis::{FromRedisValue, ToRedisArgs};
 
 lazy_static! {
@@ -9,29 +9,42 @@ lazy_static! {
     };
 }
 
-pub async fn cache_set_key<'a, 
+pub async fn cache_del_key<'a, 
     K: ToRedisArgs + Send + Sync + 'a,
-    V: ToRedisArgs + Send + Sync + 'a,
     RV: FromRedisValue
-> (key: K, value: V, exp_time: u64) -> RV {
+> (key: K) -> Result<RV, RedisError> {
     let redis_client = &mut redis::Client::open(REDIS_URL.to_owned())
         .unwrap()
         .get_multiplexed_tokio_connection()
         .await
         .unwrap();
 
-    return redis_client.set_ex::<K, V, RV>(key, value, exp_time).await.unwrap();
+    return redis_client.del(key).await;
+}
+
+pub async fn cache_set_key<'a, 
+    K: ToRedisArgs + Send + Sync + 'a,
+    V: ToRedisArgs + Send + Sync + 'a,
+    RV: FromRedisValue
+> (key: K, value: V, exp_time: u64) -> Result<RV, RedisError> {
+    let redis_client = &mut redis::Client::open(REDIS_URL.to_owned())
+        .unwrap()
+        .get_multiplexed_tokio_connection()
+        .await
+        .unwrap();
+
+    return redis_client.set_ex::<K, V, RV>(key, value, exp_time).await;
 }
 
 pub async fn cache_get_key<'a, 
     K: ToRedisArgs + Send + Sync + 'a,
     RV: FromRedisValue
-> (key: K) -> RV {
+> (key: K) -> Result<RV, RedisError> {
     let redis_client = &mut redis::Client::open(REDIS_URL.to_owned())
         .unwrap()
         .get_multiplexed_tokio_connection()
         .await
         .unwrap();
 
-    return redis_client.get::<K, RV>(key).await.unwrap();
+    return redis_client.get::<K, RV>(key).await;
 }

--- a/src/services/redis_client.rs
+++ b/src/services/redis_client.rs
@@ -1,9 +1,7 @@
 use lazy_static::lazy_static;
 use dotenvy_macro::dotenv;
 use redis::AsyncCommands;
-use redis::RedisError;
-use redis::ToRedisArgs;
-use redis::FromRedisValue;
+use redis::{FromRedisValue, ToRedisArgs};
 
 lazy_static! {
     static ref REDIS_URL: String = {
@@ -11,29 +9,29 @@ lazy_static! {
     };
 }
 
-pub async fn set_key<'a, 
+pub async fn cache_set_key<'a, 
     K: ToRedisArgs + Send + Sync + 'a,
     V: ToRedisArgs + Send + Sync + 'a,
     RV: FromRedisValue
-> (key: K, value: V, exp_time: u64) -> Result<RV, RedisError> {
+> (key: K, value: V, exp_time: u64) -> RV {
     let redis_client = &mut redis::Client::open(REDIS_URL.to_owned())
         .unwrap()
         .get_multiplexed_tokio_connection()
         .await
         .unwrap();
-    
-    return redis_client.set_ex::<K, V, RV>(key, value, exp_time).await; 
+
+    return redis_client.set_ex::<K, V, RV>(key, value, exp_time).await.unwrap();
 }
 
-pub async fn get_key<'a, 
+pub async fn cache_get_key<'a, 
     K: ToRedisArgs + Send + Sync + 'a,
     RV: FromRedisValue
-> (key: K) -> Result<RV, RedisError> {
+> (key: K) -> RV {
     let redis_client = &mut redis::Client::open(REDIS_URL.to_owned())
         .unwrap()
         .get_multiplexed_tokio_connection()
         .await
         .unwrap();
 
-    return redis_client.get::<K, RV>(key).await;
+    return redis_client.get::<K, RV>(key).await.unwrap();
 }

--- a/src/services/redis_client.rs
+++ b/src/services/redis_client.rs
@@ -1,0 +1,39 @@
+use lazy_static::lazy_static;
+use dotenvy_macro::dotenv;
+use redis::AsyncCommands;
+use redis::RedisError;
+use redis::ToRedisArgs;
+use redis::FromRedisValue;
+
+lazy_static! {
+    static ref REDIS_URL: String = {
+        format!("redis://:{}@{}", dotenv!("REDIS_PASSWORD"), dotenv!("REDIS_ADDRESS"))
+    };
+}
+
+pub async fn set_key<'a, 
+    K: ToRedisArgs + Send + Sync + 'a,
+    V: ToRedisArgs + Send + Sync + 'a,
+    RV: FromRedisValue
+> (key: K, value: V, exp_time: u64) -> Result<RV, RedisError> {
+    let redis_client = &mut redis::Client::open(REDIS_URL.to_owned())
+        .unwrap()
+        .get_multiplexed_tokio_connection()
+        .await
+        .unwrap();
+    
+    return redis_client.set_ex::<K, V, RV>(key, value, exp_time).await; 
+}
+
+pub async fn get_key<'a, 
+    K: ToRedisArgs + Send + Sync + 'a,
+    RV: FromRedisValue
+> (key: K) -> Result<RV, RedisError> {
+    let redis_client = &mut redis::Client::open(REDIS_URL.to_owned())
+        .unwrap()
+        .get_multiplexed_tokio_connection()
+        .await
+        .unwrap();
+
+    return redis_client.get::<K, RV>(key).await;
+}


### PR DESCRIPTION
## O que esse PR faz?
- Reelabora o algoritmo de cadastro de usuário, permitindo que apenas o admin cadastre os usuários, mas apenas os usuários novos que foram cadastrados possam definir suas senhas
- Cria a rota de activate-user para os usuários novos ativarem a conta, passando um hash no path.

- Criar a rota de resend-activation-hash, que permite aos usuários que demoraram a ativar suas contas gerar novamente o hash para receber o novo via email, além de criar novamente o par chave-valor no cache.
## Checklist para o desenvolvedor
- [x] Lembrou de tipar as variáveis, métodos, atributos e etc
- [x] Revisou cada ponto do seu código?
- [x] Realizou devidamente os testes na sua máquina?
- [x] Setou a label corretamente?
- [x] Atribuiu/Marcou nos comentários os revisores no PR?
- [x] Este PR só possui o que realmente ele deve fazer (Task)?
## Onde a revisão poderia começar?
* src/http/controllers/user_controller.rs
* src/http/requests/user/user_activate_request.rs
* src/http/requests/user/user_resend_activation_hash_request.rs
* src/services/redis_client.rs